### PR TITLE
add terrain declaration support to modfiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@rbxts/dl-modfile-packager",
-	"version": "0.23.0-dev-3",
+	"version": "0.24.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@rbxts/dl-modfile-packager",
-			"version": "0.23.0-dev-3",
+			"version": "0.24.0",
 			"license": "ISC",
 			"dependencies": {
 				"@rbxts/bitbuffer": "^1.1.1-ts.1",

--- a/src/namespace/Encode.ts
+++ b/src/namespace/Encode.ts
@@ -99,7 +99,7 @@ export namespace Encode {
 				instance: data,
 			});
 
-			const terrain_zones = folder.FindFirstChild("terrain");
+			const terrain_zones = data.FindFirstChild("terrain");
 			if (terrain_zones !== undefined) {
 				const terrain_region = terrain_zones.FindFirstChildWhichIsA("BasePart");
 				if (terrain_region !== undefined) {

--- a/src/namespace/Encode.ts
+++ b/src/namespace/Encode.ts
@@ -12,7 +12,7 @@ import { SerializeLightingPresetDeclaration } from "../serialize/type/lighting_p
 import { SerializeTerrainDeclaration } from "../serialize/type/terrain";
 import { Workspace } from "@rbxts/services";
 
-function isAxisAligned(part: BasePart): boolean {
+function is_axis_aligned(part: BasePart): boolean {
 	if (part.Orientation.X % 90 !== 0) return false;
 	if (part.Orientation.Y % 90 !== 0) return false;
 	if (part.Orientation.Z % 90 !== 0) return false;
@@ -99,24 +99,24 @@ export namespace Encode {
 				instance: data,
 			});
 
-			const terrainZones = folder.FindFirstChild("terrain");
-			if (terrainZones !== undefined) {
-				const terrainRegion = terrainZones.FindFirstChildWhichIsA("BasePart");
-				if (terrainRegion !== undefined) {
-					if (!isAxisAligned(terrainRegion)) {
+			const terrain_zones = folder.FindFirstChild("terrain");
+			if (terrain_zones !== undefined) {
+				const terrain_region = terrain_zones.FindFirstChildWhichIsA("BasePart");
+				if (terrain_region !== undefined) {
+					if (!is_axis_aligned(terrain_region)) {
 						warn(
-							`Terrain region ${terrainRegion.GetFullName()} is not aligned to the X, Y and Z axes! This will be skipped for terrain reading!`,
+							`Terrain region ${terrain_region.GetFullName()} is not aligned to the X, Y and Z axes! This will be skipped for terrain reading!`,
 						);
 					} else {
-						const voxelRegion = new Region3(
-							(terrainRegion.Position = terrainRegion.Size.div(2)),
-							terrainRegion.Position.add(terrainRegion.Size.div(2)),
+						const voxel_region = new Region3(
+							(terrain_region.Position = terrain_region.Size.div(2)),
+							terrain_region.Position.add(terrain_region.Size.div(2)),
 						).ExpandToGrid(4);
 
-						const [materials, occupancies] = Workspace.Terrain.ReadVoxels(voxelRegion, 4);
+						const [materials, occupancies] = Workspace.Terrain.ReadVoxels(voxel_region, 4);
 
 						WRITE_MODULE(SerializeTerrainDeclaration, buffer, {
-							region: voxelRegion,
+							region: voxel_region,
 							materials,
 							occupancies,
 						});

--- a/src/serialize/module.ts
+++ b/src/serialize/module.ts
@@ -7,6 +7,7 @@ import { SerializeMetadataDeclaration } from "./type/metadata";
 import { SerializeMapDeclaration } from "./type/map";
 import { SerializeScriptDeclaration } from "./type/script";
 import { SerializeLightingPresetDeclaration } from "./type/lighting_preset";
+import { SerializeTerrainDeclaration } from "./type/terrain";
 
 export type Serializer<T> = {
 	write: (arg: T, buffer: BitBuffer) => void;
@@ -23,6 +24,7 @@ const serializers = [
 	SerializeMapDeclaration,
 	SerializeScriptDeclaration,
 	SerializeLightingPresetDeclaration,
+	SerializeTerrainDeclaration,
 ];
 
 export function WRITE_MODULE<T>(module: Serializer<T>, buffer: BitBuffer, data: T) {

--- a/src/serialize/module.ts
+++ b/src/serialize/module.ts
@@ -15,7 +15,7 @@ export type Serializer<T> = {
 	id: number; // must be unique
 };
 
-let serializers = [
+const serializers = [
 	SerializeAttachmentDeclaration,
 	SerializeClassDeclaration,
 	SerializeMetadataDeclaration,
@@ -31,11 +31,11 @@ export function WRITE_MODULE<T>(module: Serializer<T>, buffer: BitBuffer, data: 
 }
 
 export function DECODE_MODULE<T>(file: Modfile.file, buffer: BitBuffer): boolean | undefined {
-	let id = buffer.readUnsigned(4);
+	const id = buffer.readUnsigned(4);
 
 	if (id === undefined) return;
 
-	let serializer = serializers.find((value) => value.id === id);
+	const serializer = serializers.find((value) => value.id === id);
 	if (!serializer) throw `invalid module ID ${id}`;
 
 	serializer.decode(file, buffer);

--- a/src/serialize/type/terrain.ts
+++ b/src/serialize/type/terrain.ts
@@ -3,70 +3,85 @@ import { Deadline, Modfile } from "../..";
 import { Serializer } from "../module";
 import { SerializeId } from "../types";
 
-const MATERIAL_TO_INT = new Map<Enum.Material, number>([
-	[Enum.Material.Air, 0],
-	[Enum.Material.Asphalt, 1],
-	[Enum.Material.Basalt, 2],
-	[Enum.Material.Brick, 3],
-	[Enum.Material.Cobblestone, 4],
-	[Enum.Material.Concrete, 5],
-	[Enum.Material.CrackedLava, 6],
-	[Enum.Material.Glacier, 7],
-	[Enum.Material.Grass, 8],
-	[Enum.Material.Ground, 9],
-	[Enum.Material.Ice, 10],
-	[Enum.Material.LeafyGrass, 11],
-	[Enum.Material.Limestone, 12],
-	[Enum.Material.Mud, 13],
-	[Enum.Material.Pavement, 14],
-	[Enum.Material.Rock, 15],
-	[Enum.Material.Salt, 16],
-	[Enum.Material.Sand, 17],
-	[Enum.Material.Sandstone, 18],
-	[Enum.Material.Slate, 19],
-	[Enum.Material.Snow, 20],
-	[Enum.Material.Water, 21],
-	[Enum.Material.WoodPlanks, 22],
-]);
+const MATERIAL_TO_INT = new Map<Enum.Material, number>(
+	Enum.Material.GetEnumItems().map((material) => [material, material.Value]),
+);
 
-export const SerializeTerrainDeclaration: Serializer<Modfile.scriptDeclaration> = {
+const INT_TO_MATERIAL = new Map<number, Enum.Material>(
+	Enum.Material.GetEnumItems().map((material) => [material.Value, material]),
+);
+
+export const SerializeTerrainDeclaration: Serializer<{
+	region: Region3;
+	occupancies: ReadVoxelsArray<number>;
+	materials: ReadVoxelsArray<Enum.Material>;
+}> = {
 	name: "Terrain",
 	id: SerializeId.Terrain,
 	write: (declaration, bitbuffer) => {
-		let region = Workspace.Terrain.MaxExtents;
+		bitbuffer.writeRegion3(declaration.region);
 
-		let last_timeout = os.clock();
+		bitbuffer.writeUInt32(declaration.occupancies.size());
+		bitbuffer.writeUInt32(declaration.occupancies[0]?.size() ?? 0);
+		bitbuffer.writeUInt32(declaration.occupancies[0]?.[0]?.size() ?? 0);
 
-		bitbuffer.writeSigned(64, region.Min.X);
-		bitbuffer.writeSigned(64, region.Min.Y);
-		bitbuffer.writeSigned(64, region.Min.Z);
-		bitbuffer.writeSigned(64, region.Max.X);
-		bitbuffer.writeSigned(64, region.Max.Y);
-		bitbuffer.writeSigned(64, region.Max.Z);
-		for (const x of $range(region.Min.X, region.Max.X)) {
-			for (const y of $range(region.Min.Y, region.Max.Y)) {
-				for (const z of $range(region.Min.Z, region.Max.Z)) {
-					if (last_timeout + 0.5 < os.clock()) {
-						RunService.Heartbeat.Wait();
-						last_timeout = os.clock();
-					}
+		for (const x of $range(0, declaration.occupancies.size() - 1)) {
+			const xOcc = declaration.occupancies[x];
+			const xMat = declaration.materials[x];
 
-					let region = new Region3(new Vector3(x, y, z), new Vector3(x + 4, y + 4, z + 4));
-					let [materials, occupancies] = Workspace.Terrain.ReadVoxels(region, 4);
+			for (const y of $range(0, xOcc.size() - 1)) {
+				const yOcc = xOcc[y];
+				const yMat = xMat[y];
 
-					let material_int = MATERIAL_TO_INT.get(materials[0][0][0]) ?? 0;
-					let occupancy = occupancies[0][0][0];
+				for (const z of $range(0, yOcc.size() - 1)) {
+					const occupancy = yOcc[z];
+					const material = yMat[z];
 
-					bitbuffer.writeUnsigned(8, material_int);
-					let value = math.floor((occupancy ?? 1) * 16);
-					if (value > 16) print(value);
-
-					bitbuffer.writeUnsigned(5, (occupancy ?? 1) * 16);
+					bitbuffer.writeUInt32(material.Value);
+					bitbuffer.writeFloat64(occupancy);
 				}
 			}
 		}
 	},
 	decode: (modfile, buffer) => {
-		return modfile;
+		const region = buffer.readRegion3();
+
+		const xSize = buffer.readUInt32();
+		const ySize = buffer.readUInt32();
+		const zSize = buffer.readUInt32();
+
+		const occupancies: Array<Array<Array<number>>> = new Array(xSize);
+		const materials: Array<Array<Array<Enum.Material>>> = new Array(xSize);
+		for (const x of $range(0, xSize - 1)) {
+			const yOcc = new Array<Array<number>>(ySize);
+			const yMat = new Array<Array<Enum.Material>>(ySize);
+
+			occupancies[x] = yOcc;
+			materials[x] = yMat;
+
+			for (const y of $range(0, ySize - 1)) {
+				const zOcc = new Array<number>(zSize);
+				const zMat = new Array<Enum.Material>(zSize);
+
+				yOcc[y] = zOcc;
+				yMat[y] = zMat;
+
+				for (const z of $range(0, zSize - 1)) {
+					const material = buffer.readUInt32();
+					const occupancy = buffer.readFloat64();
+
+					zOcc[z] = occupancy;
+					zMat[z] = INT_TO_MATERIAL.get(material)!;
+				}
+			}
+		}
+
+		const declaration: Modfile.terrainDeclaration = { region, occupancies, materials };
+
+		Workspace.Terrain.WriteVoxels(region, 4, materials, occupancies);
+
+		modfile.terrain_declarations.push(declaration);
+
+		return declaration;
 	},
 };

--- a/src/serialize/type/terrain.ts
+++ b/src/serialize/type/terrain.ts
@@ -26,16 +26,16 @@ export const SerializeTerrainDeclaration: Serializer<{
 		bitbuffer.writeUInt32(declaration.occupancies[0]?.[0]?.size() ?? 0);
 
 		for (const x of $range(0, declaration.occupancies.size() - 1)) {
-			const xOcc = declaration.occupancies[x];
-			const xMat = declaration.materials[x];
+			const x_occ = declaration.occupancies[x];
+			const x_mat = declaration.materials[x];
 
-			for (const y of $range(0, xOcc.size() - 1)) {
-				const yOcc = xOcc[y];
-				const yMat = xMat[y];
+			for (const y of $range(0, x_occ.size() - 1)) {
+				const y_occ = x_occ[y];
+				const y_mat = x_mat[y];
 
-				for (const z of $range(0, yOcc.size() - 1)) {
-					const occupancy = yOcc[z];
-					const material = yMat[z];
+				for (const z of $range(0, y_occ.size() - 1)) {
+					const occupancy = y_occ[z];
+					const material = y_mat[z];
 
 					bitbuffer.writeUInt32(material.Value);
 					bitbuffer.writeFloat64(occupancy);
@@ -46,39 +46,37 @@ export const SerializeTerrainDeclaration: Serializer<{
 	decode: (modfile, buffer) => {
 		const region = buffer.readRegion3();
 
-		const xSize = buffer.readUInt32();
-		const ySize = buffer.readUInt32();
-		const zSize = buffer.readUInt32();
+		const x_size = buffer.readUInt32();
+		const y_size = buffer.readUInt32();
+		const z_size = buffer.readUInt32();
 
-		const occupancies: Array<Array<Array<number>>> = new Array(xSize);
-		const materials: Array<Array<Array<Enum.Material>>> = new Array(xSize);
-		for (const x of $range(0, xSize - 1)) {
-			const yOcc = new Array<Array<number>>(ySize);
-			const yMat = new Array<Array<Enum.Material>>(ySize);
+		const occupancies: Array<Array<Array<number>>> = new Array(x_size);
+		const materials: Array<Array<Array<Enum.Material>>> = new Array(x_size);
+		for (const x of $range(0, x_size - 1)) {
+			const y_occ = new Array<Array<number>>(y_size);
+			const y_mat = new Array<Array<Enum.Material>>(y_size);
 
-			occupancies[x] = yOcc;
-			materials[x] = yMat;
+			occupancies[x] = y_occ;
+			materials[x] = y_mat;
 
-			for (const y of $range(0, ySize - 1)) {
-				const zOcc = new Array<number>(zSize);
-				const zMat = new Array<Enum.Material>(zSize);
+			for (const y of $range(0, y_size - 1)) {
+				const z_occ = new Array<number>(z_size);
+				const z_mat = new Array<Enum.Material>(z_size);
 
-				yOcc[y] = zOcc;
-				yMat[y] = zMat;
+				y_occ[y] = z_occ;
+				y_mat[y] = z_mat;
 
-				for (const z of $range(0, zSize - 1)) {
+				for (const z of $range(0, z_size - 1)) {
 					const material = buffer.readUInt32();
 					const occupancy = buffer.readFloat64();
 
-					zOcc[z] = occupancy;
-					zMat[z] = INT_TO_MATERIAL.get(material)!;
+					z_occ[z] = occupancy;
+					z_mat[z] = INT_TO_MATERIAL.get(material)!;
 				}
 			}
 		}
 
 		const declaration: Modfile.terrainDeclaration = { region, occupancies, materials };
-
-		Workspace.Terrain.WriteVoxels(region, 4, materials, occupancies);
 
 		modfile.terrain_declarations.push(declaration);
 


### PR DESCRIPTION
Added a serializer declaration for terrain. This requires the user to add a folder named terrain inside of the map file, with a part in that folder which acts as the region to read terrain from. A future implementation could convert the map bounds into a region to automatically read terrain from if needed, but that is not exhaustive or reliable.

I did not implement significant compression for terrain data as zlib compression will perform adequately in cross-item compression, and automatic compression of material enums is the only real option but has complications with support for new materials being added by roblox.

Each voxel uses a uint32 for the material and a float64 for the occupancy. float32 could be an option but it would lose precision, and with imprecise terrain geometry that could produce unintended compression artifacts.